### PR TITLE
Optimize preprocessing initialization phase

### DIFF
--- a/category_classification/models.py
+++ b/category_classification/models.py
@@ -59,20 +59,9 @@ class KerasPreprocessing:
     category_vocab: List[str]
 
 
-def _count_occurrances(df_col: pd.Series) -> Dict[str, int]:
-    counts = defaultdict(int)
-
-    for vals in df_col:
-        for val in vals:
-            counts[val] += 1
-
-    return counts
-
-
 def _construct_preprocessing_vocab(df_col: pd.Series, min_count: int) -> List[str]:
-    counts = _count_occurrances(df_col)
-
-    return [item for item, count in counts.items() if count >= min_count]
+    s = df_col.explode().value_counts()
+    return s.where(s >= min_count).dropna().index.values
 
 
 def construct_preprocessing(

--- a/category_classification/models.py
+++ b/category_classification/models.py
@@ -83,7 +83,7 @@ def construct_preprocessing(
         max_tokens=max_product_name_tokens,
         output_sequence_length=max_product_name_length,
     )
-    product_name_preprocessing.adapt(train_df.product_name)
+    product_name_preprocessing.adapt(train_df["product_name"], batch_size=50_000)
 
     ingredient_vocab = _construct_preprocessing_vocab(
         train_df["known_ingredient_tags"], ingredients_min_count

--- a/experiments/Train.ipynb
+++ b/experiments/Train.ipynb
@@ -292,8 +292,8 @@
      "output_type": "stream",
      "text": [
       "Pre-processed training data\n",
-      "CPU times: user 4min 37s, sys: 3.97 s, total: 4min 41s\n",
-      "Wall time: 4min 27s\n"
+      "CPU times: user 2.2 s, sys: 39.5 ms, total: 2.24 s\n",
+      "Wall time: 2.06 s\n"
      ]
     }
    ],
@@ -304,7 +304,7 @@
     "    model_config.ingredient_min_count,\n",
     "    model_config.product_name_max_tokens,\n",
     "    model_config.product_name_max_length,\n",
-    "    load_dataframe(\"train\"),\n",
+    "    training_ds,\n",
     ")\n",
     "print(\"Pre-processed training data\")"
    ]


### PR DESCRIPTION
Optimize the `construct_preprocessing` function with the following changes:
- Set large batch size to `TextVecorizer.adapt` (this is the largest gain).
- Reuse already loaded training dataframe.
- Replace python occurrence counting with pandas operations.

With those 3 changes, calling `construct_preprocessing` goes from around 4mn to around 2s.