### PR TITLE
fix: Add agribalyse_categories.txt to download files

### DIFF
--- a/download.sh
+++ b/download.sh
@@ -9,3 +9,4 @@ wget https://github.com/openfoodfacts/openfoodfacts-ai/releases/download/${RELEA
 wget https://github.com/openfoodfacts/openfoodfacts-ai/releases/download/${RELEASE}/category_${LANG}.test.jsonl.gz
 wget https://github.com/openfoodfacts/openfoodfacts-ai/releases/download/${RELEASE}/category_${LANG}.train.jsonl.gz
 wget https://github.com/openfoodfacts/openfoodfacts-ai/releases/download/${RELEASE}/category_${LANG}.val.jsonl.gz
+wget https://github.com/openfoodfacts/openfoodfacts-ai/releases/download/${RELEASE}/agribalyse_categories.txt


### PR DESCRIPTION
File recreated using https://raw.githubusercontent.com/openfoodfacts/openfoodfacts-server/main/taxonomies/categories.result.txt
and `cat categories.json | jq -c -r '. | to_entries | .[] | select(.value.agribalyse_food_code != null) | .key' > agribalyse_categories.txt`

fixes: #19

Co-authored by: @streino
