### PR TITLE
feat: remove manual toc, use jupyter toc2 nbextension instead

### DIFF
--- a/experiments/Train.ipynb
+++ b/experiments/Train.ipynb
@@ -1,60 +1,38 @@
 {
  "cells": [
   {
-   "cell_type": "markdown",
-   "id": "064e2d60",
-   "metadata": {},
-   "source": [
-    "# INDEX\n",
-    "* [Imports and functions](#Imports-and-functions)\n",
-    "* [Configuration](#Configuration)\n",
-    "* [Prepare dataset](#Prepare-dataset)\n",
-    "* [Build model](#Build-model)\n",
-    "    * [Model inputs](#Model-inputs)\n",
-    "    * [Model output](#Model-output)\n",
-    "    * [Model](#Model)\n",
-    "* [Train model](#Train-model)\n",
-    "    * [Save model and resources](#Save-model-and-resources)\n",
-    "    * [Training stats](#Training-stats)\n",
-    "* [Test model](#Test-model)\n",
-    "    * [Predict with training model](#Predict-with-training-model)\n",
-    "    * [Predict with serving model](#Predict-with-serving-model)"
-   ]
-  },
-  {
    "cell_type": "code",
-   "execution_count": 4,
-   "id": "9bcfaa2d",
+   "execution_count": 1,
+   "id": "3d23e1f3",
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[codecarbon INFO @ 19:11:14] [setup] RAM Tracking...\n",
-      "[codecarbon INFO @ 19:11:14] [setup] GPU Tracking...\n",
-      "[codecarbon INFO @ 19:11:14] No GPU found.\n",
-      "[codecarbon INFO @ 19:11:14] [setup] CPU Tracking...\n",
-      "[codecarbon DEBUG @ 19:11:14] Not using PowerGadget, an exception occurred while instantiating IntelPowerGadget : Platform not supported by Intel Power Gadget\n",
-      "[codecarbon ERROR @ 19:11:14] Unable to read Intel RAPL files for CPU power, we will use a constant for your CPU power. Please view https://github.com/mlco2/codecarbon/issues/244 for workarounds : [Errno 13] Permission denied: '/sys/class/powercap/intel-rapl/intel-rapl:1/energy_uj'\n",
-      "[codecarbon ERROR @ 19:11:14] Unable to read Intel RAPL files for CPU power, we will use a constant for your CPU power. Please view https://github.com/mlco2/codecarbon/issues/244 for workarounds : [Errno 13] Permission denied: '/sys/class/powercap/intel-rapl/intel-rapl:0/energy_uj'\n",
-      "[codecarbon INFO @ 19:11:14] Tracking Intel CPU via RAPL interface\n",
-      "[codecarbon ERROR @ 19:11:16] Unable to read Intel RAPL files for CPU power, we will use a constant for your CPU power. Please view https://github.com/mlco2/codecarbon/issues/244 for workarounds : [Errno 13] Permission denied: '/sys/class/powercap/intel-rapl/intel-rapl:1/energy_uj'\n",
-      "[codecarbon ERROR @ 19:11:16] Unable to read Intel RAPL files for CPU power, we will use a constant for your CPU power. Please view https://github.com/mlco2/codecarbon/issues/244 for workarounds : [Errno 13] Permission denied: '/sys/class/powercap/intel-rapl/intel-rapl:0/energy_uj'\n",
-      "[codecarbon INFO @ 19:11:16] >>> Tracker's metadata:\n",
-      "[codecarbon INFO @ 19:11:16]   Platform system: Linux-5.13.0-41-generic-x86_64-with-glibc2.34\n",
-      "[codecarbon INFO @ 19:11:16]   Python version: 3.9.7\n",
-      "[codecarbon INFO @ 19:11:16]   Available RAM : 31.054 GB\n",
-      "[codecarbon INFO @ 19:11:16]   CPU count: 8\n",
-      "[codecarbon INFO @ 19:11:16]   CPU model: Intel(R) Core(TM) i7-10510U CPU @ 1.80GHz\n",
-      "[codecarbon INFO @ 19:11:16]   GPU count: None\n",
-      "[codecarbon INFO @ 19:11:16]   GPU model: None\n",
-      "[codecarbon DEBUG @ 19:11:17] Not running on AWS, couldn't retrieve metadata: ConnectTimeout(MaxRetryError(\"HTTPConnectionPool(host='169.254.169.254', port=80): Max retries exceeded with url: /latest/dynamic/instance-identity/document (Caused by ConnectTimeoutError(<urllib3.connection.HTTPConnection object at 0x7f0b812e8ee0>, 'Connection to 169.254.169.254 timed out. (connect timeout=1)'))\"))\n",
-      "[codecarbon DEBUG @ 19:11:18] Not running on Azure, couldn't retrieve metadata: ConnectTimeout(MaxRetryError(\"HTTPConnectionPool(host='169.254.169.254', port=80): Max retries exceeded with url: /metadata/instance?api-version=2019-08-15 (Caused by ConnectTimeoutError(<urllib3.connection.HTTPConnection object at 0x7f0b9a56cbe0>, 'Connection to 169.254.169.254 timed out. (connect timeout=1)'))\"))\n",
-      "[codecarbon DEBUG @ 19:11:19] Not running on GCP, couldn't retrieve metadata: ConnectTimeout(MaxRetryError(\"HTTPConnectionPool(host='169.254.169.254', port=80): Max retries exceeded with url: /computeMetadata/v1/instance/?recursive=true&alt=json (Caused by ConnectTimeoutError(<urllib3.connection.HTTPConnection object at 0x7f0ad8d57ac0>, 'Connection to 169.254.169.254 timed out. (connect timeout=1)'))\"))\n",
-      "[codecarbon INFO @ 19:11:19] ApiClient Successfully registered your run on the API.\n",
+      "[codecarbon INFO @ 08:40:52] [setup] RAM Tracking...\n",
+      "[codecarbon INFO @ 08:40:52] [setup] GPU Tracking...\n",
+      "[codecarbon INFO @ 08:40:52] No GPU found.\n",
+      "[codecarbon INFO @ 08:40:52] [setup] CPU Tracking...\n",
+      "[codecarbon DEBUG @ 08:40:52] Not using PowerGadget, an exception occurred while instantiating IntelPowerGadget : Intel Power Gadget executable not found on darwin\n",
+      "[codecarbon DEBUG @ 08:40:52] Not using the RAPL interface, an exception occurred while instantiating IntelRAPL : Platform not supported by Intel RAPL Interface\n",
+      "[codecarbon WARNING @ 08:40:52] No CPU tracking mode found. Falling back on CPU constant mode.\n",
+      "[codecarbon DEBUG @ 08:40:53] CPU : We detect a Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz with a TDP of 45 W\n",
+      "[codecarbon INFO @ 08:40:53] CPU Model on constant consumption mode: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz\n",
+      "[codecarbon INFO @ 08:40:53] >>> Tracker's metadata:\n",
+      "[codecarbon INFO @ 08:40:53]   Platform system: macOS-10.16-x86_64-i386-64bit\n",
+      "[codecarbon INFO @ 08:40:53]   Python version: 3.8.0\n",
+      "[codecarbon INFO @ 08:40:53]   Available RAM : 16.000 GB\n",
+      "[codecarbon INFO @ 08:40:53]   CPU count: 12\n",
+      "[codecarbon INFO @ 08:40:53]   CPU model: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz\n",
+      "[codecarbon INFO @ 08:40:53]   GPU count: None\n",
+      "[codecarbon INFO @ 08:40:53]   GPU model: None\n",
+      "[codecarbon DEBUG @ 08:40:54] Not running on AWS, couldn't retrieve metadata: ConnectTimeout(MaxRetryError(\"HTTPConnectionPool(host='169.254.169.254', port=80): Max retries exceeded with url: /latest/dynamic/instance-identity/document (Caused by ConnectTimeoutError(<urllib3.connection.HTTPConnection object at 0x7faf3ab93be0>, 'Connection to 169.254.169.254 timed out. (connect timeout=1)'))\"))\n",
+      "[codecarbon DEBUG @ 08:40:55] Not running on Azure, couldn't retrieve metadata: ConnectTimeout(MaxRetryError(\"HTTPConnectionPool(host='169.254.169.254', port=80): Max retries exceeded with url: /metadata/instance?api-version=2019-08-15 (Caused by ConnectTimeoutError(<urllib3.connection.HTTPConnection object at 0x7faf3acef640>, 'Connection to 169.254.169.254 timed out. (connect timeout=1)'))\"))\n",
+      "[codecarbon DEBUG @ 08:40:56] Not running on GCP, couldn't retrieve metadata: ConnectTimeout(MaxRetryError(\"HTTPConnectionPool(host='169.254.169.254', port=80): Max retries exceeded with url: /computeMetadata/v1/instance/?recursive=true&alt=json (Caused by ConnectTimeoutError(<urllib3.connection.HTTPConnection object at 0x7faf3ab93700>, 'Connection to 169.254.169.254 timed out. (connect timeout=1)'))\"))\n",
+      "[codecarbon INFO @ 08:40:56] ApiClient Successfully registered your run on the API.\n",
       "\n",
-      "Run ID: 88262eed-3106-4e63-a0dc-d693321ec90e\n",
+      "Run ID: 33635ffd-9142-4353-a5e1-a4ada68ccd8f\n",
       "Experiment ID: fb3eafba-8f68-4ba0-9053-fb1746ae4a8d\n",
       "\n"
      ]
@@ -70,7 +48,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d481d404",
+   "id": "a9884c52",
    "metadata": {},
    "source": [
     "# Imports and functions"
@@ -78,8 +56,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
-   "id": "80c4f3c2",
+   "execution_count": 2,
+   "id": "22666b5c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -89,10 +67,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
-   "id": "fda92a68",
+   "execution_count": 3,
+   "id": "f20b47d4",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/hui-guan/opt/miniconda3/envs/off/lib/python3.8/site-packages/tqdm/auto.py:22: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
+      "  from .autonotebook import tqdm as notebook_tqdm\n",
+      "[codecarbon INFO @ 08:41:11] Energy consumed for RAM : 0.000025 kWh. RAM Power : 6.0 W\n",
+      "[codecarbon DEBUG @ 08:41:11] RAM : 6.00 W during 15.00 s [measurement time: 0.0014]\n",
+      "[codecarbon INFO @ 08:41:11] Energy consumed for all CPUs : 0.000094 kWh. All CPUs Power : 22.5 W\n",
+      "[codecarbon DEBUG @ 08:41:11] CPU : 22.50 W during 15.01 s [measurement time: 0.0010]\n",
+      "[codecarbon INFO @ 08:41:11] 0.000119 kWh of electricity used since the begining.\n",
+      "[codecarbon DEBUG @ 08:41:11] last_duration=15.006764888763428\n",
+      "------------------------\n"
+     ]
+    }
+   ],
    "source": [
     "import dacite\n",
     "import json\n",
@@ -121,7 +115,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b1bfc7ed",
+   "id": "edf31926",
    "metadata": {},
    "source": [
     "# Configuration"
@@ -129,8 +123,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
-   "id": "a92c3dd7",
+   "execution_count": 4,
+   "id": "785775f0",
    "metadata": {
     "scrolled": true
    },
@@ -157,7 +151,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "24785109",
+   "id": "c61b56fd",
    "metadata": {},
    "source": [
     "# Prepare dataset\n",
@@ -170,8 +164,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
-   "id": "cda1dad4",
+   "execution_count": 5,
+   "id": "a202df7d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -186,7 +180,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "eb92b58e",
+   "id": "10f5829b",
    "metadata": {},
    "source": [
     "# Build model"
@@ -194,8 +188,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
-   "id": "2ee58091",
+   "execution_count": 6,
+   "id": "1972212e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -204,7 +198,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "993bb1d8",
+   "id": "43834c4c",
    "metadata": {},
    "source": [
     "## Model inputs"
@@ -212,8 +206,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
-   "id": "531185de",
+   "execution_count": 7,
+   "id": "da6522c2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -224,19 +218,193 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
-   "id": "8353a5f1",
+   "execution_count": 8,
+   "id": "c410dc99",
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2022-05-20 19:11:19.719797: W tensorflow/stream_executor/platform/default/dso_loader.cc:64] Could not load dynamic library 'libcuda.so.1'; dlerror: libcuda.so.1: cannot open shared object file: No such file or directory\n",
-      "2022-05-20 19:11:19.719865: W tensorflow/stream_executor/cuda/cuda_driver.cc:269] failed call to cuInit: UNKNOWN ERROR (303)\n",
-      "2022-05-20 19:11:19.719905: I tensorflow/stream_executor/cuda/cuda_diagnostics.cc:156] kernel driver does not appear to be running on this host (tignasse): /proc/driver/nvidia/version does not exist\n",
-      "2022-05-20 19:11:19.720575: I tensorflow/core/platform/cpu_feature_guard.cc:142] This TensorFlow binary is optimized with oneAPI Deep Neural Network Library (oneDNN) to use the following CPU instructions in performance-critical operations:  AVX2 FMA\n",
-      "To enable them in other operations, rebuild TensorFlow with the appropriate compiler flags.\n"
+      "[codecarbon INFO @ 08:41:26] Energy consumed for RAM : 0.000050 kWh. RAM Power : 6.0 W\n",
+      "[codecarbon DEBUG @ 08:41:26] RAM : 6.00 W during 15.00 s [measurement time: 0.0017]\n",
+      "[codecarbon INFO @ 08:41:26] Energy consumed for all CPUs : 0.000188 kWh. All CPUs Power : 22.5 W\n",
+      "[codecarbon DEBUG @ 08:41:26] CPU : 22.50 W during 15.00 s [measurement time: 0.0008]\n",
+      "[codecarbon INFO @ 08:41:26] 0.000238 kWh of electricity used since the begining.\n",
+      "[codecarbon DEBUG @ 08:41:26] last_duration=14.998652219772339\n",
+      "------------------------\n",
+      "[codecarbon INFO @ 08:41:41] Energy consumed for RAM : 0.000075 kWh. RAM Power : 6.0 W\n",
+      "[codecarbon DEBUG @ 08:41:41] RAM : 6.00 W during 15.00 s [measurement time: 0.0014]\n",
+      "[codecarbon INFO @ 08:41:41] Energy consumed for all CPUs : 0.000281 kWh. All CPUs Power : 22.5 W\n",
+      "[codecarbon DEBUG @ 08:41:41] CPU : 22.50 W during 15.00 s [measurement time: 0.0009]\n",
+      "[codecarbon INFO @ 08:41:41] 0.000356 kWh of electricity used since the begining.\n",
+      "[codecarbon DEBUG @ 08:41:41] last_duration=15.00143814086914\n",
+      "------------------------\n",
+      "[codecarbon INFO @ 08:41:56] Energy consumed for RAM : 0.000100 kWh. RAM Power : 6.0 W\n",
+      "[codecarbon DEBUG @ 08:41:56] RAM : 6.00 W during 15.00 s [measurement time: 0.0015]\n",
+      "[codecarbon INFO @ 08:41:56] Energy consumed for all CPUs : 0.000375 kWh. All CPUs Power : 22.5 W\n",
+      "[codecarbon DEBUG @ 08:41:56] CPU : 22.50 W during 15.00 s [measurement time: 0.0009]\n",
+      "[codecarbon INFO @ 08:41:56] 0.000475 kWh of electricity used since the begining.\n",
+      "[codecarbon DEBUG @ 08:41:56] last_duration=14.998591899871826\n",
+      "------------------------\n",
+      "[codecarbon INFO @ 08:42:11] Energy consumed for RAM : 0.000125 kWh. RAM Power : 6.0 W\n",
+      "[codecarbon DEBUG @ 08:42:11] RAM : 6.00 W during 15.00 s [measurement time: 0.0016]\n",
+      "[codecarbon INFO @ 08:42:11] Energy consumed for all CPUs : 0.000469 kWh. All CPUs Power : 22.5 W\n",
+      "[codecarbon DEBUG @ 08:42:11] CPU : 22.50 W during 15.00 s [measurement time: 0.0009]\n",
+      "[codecarbon INFO @ 08:42:11] 0.000594 kWh of electricity used since the begining.\n",
+      "[codecarbon DEBUG @ 08:42:11] last_duration=14.997385263442993\n",
+      "------------------------\n",
+      "[codecarbon INFO @ 08:42:26] Energy consumed for RAM : 0.000150 kWh. RAM Power : 6.0 W\n",
+      "[codecarbon DEBUG @ 08:42:26] RAM : 6.00 W during 15.00 s [measurement time: 0.0014]\n",
+      "[codecarbon INFO @ 08:42:26] Energy consumed for all CPUs : 0.000563 kWh. All CPUs Power : 22.5 W\n",
+      "[codecarbon DEBUG @ 08:42:26] CPU : 22.50 W during 15.00 s [measurement time: 0.0011]\n",
+      "[codecarbon INFO @ 08:42:26] 0.000713 kWh of electricity used since the begining.\n",
+      "[codecarbon DEBUG @ 08:42:26] last_duration=15.002096176147461\n",
+      "------------------------\n",
+      "[codecarbon INFO @ 08:42:41] Energy consumed for RAM : 0.000175 kWh. RAM Power : 6.0 W\n",
+      "[codecarbon DEBUG @ 08:42:41] RAM : 6.00 W during 15.00 s [measurement time: 0.0015]\n",
+      "[codecarbon INFO @ 08:42:41] Energy consumed for all CPUs : 0.000656 kWh. All CPUs Power : 22.5 W\n",
+      "[codecarbon DEBUG @ 08:42:41] CPU : 22.50 W during 15.00 s [measurement time: 0.0009]\n",
+      "[codecarbon INFO @ 08:42:41] 0.000831 kWh of electricity used since the begining.\n",
+      "[codecarbon DEBUG @ 08:42:41] last_duration=15.002197027206421\n",
+      "------------------------\n",
+      "[codecarbon INFO @ 08:42:56] Energy consumed for RAM : 0.000200 kWh. RAM Power : 6.0 W\n",
+      "[codecarbon DEBUG @ 08:42:56] RAM : 6.00 W during 14.99 s [measurement time: 0.0012]\n",
+      "[codecarbon INFO @ 08:42:56] Energy consumed for all CPUs : 0.000750 kWh. All CPUs Power : 22.5 W\n",
+      "[codecarbon DEBUG @ 08:42:56] CPU : 22.50 W during 15.00 s [measurement time: 0.0008]\n",
+      "[codecarbon INFO @ 08:42:56] 0.000950 kWh of electricity used since the begining.\n",
+      "[codecarbon DEBUG @ 08:42:56] We apply an energy mix of 55 g.CO2eq/kWh for France\n",
+      "[codecarbon DEBUG @ 08:42:56] EmissionsData(timestamp='2022-05-22T08:42:56', project_name='codecarbon', run_id='33635ffd-9142-4353-a5e1-a4ada68ccd8f', duration=120.02527594566345, emissions=5.2250050747394564e-05, emissions_rate=0.0004353253957195536, cpu_power=22.5, gpu_power=0.0, ram_power=6.0, cpu_energy=0.0007500239610671998, gpu_energy=0, ram_energy=0.00019997696161270145, energy_consumed=0.0009500009226799011, country_name='France', country_iso_code='FRA', region='île-de-france', cloud_provider='', cloud_region='', os='macOS-10.16-x86_64-i386-64bit', python_version='3.8.0', cpu_count=12, cpu_model='Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz', gpu_count=None, gpu_model=None, longitude=2.4075, latitude=48.8323, ram_total_size=16.0, tracking_mode='machine', on_cloud='N')\n",
+      "[codecarbon INFO @ 08:42:56] 0.000435 g.CO2eq/s mean an estimation of 13.728421679411841 kg.CO2eq/year\n",
+      "[codecarbon DEBUG @ 08:42:56] ApiClient - Successful upload emission {'timestamp': '2022-05-22T08:42:56.630837+02:00', 'run_id': '33635ffd-9142-4353-a5e1-a4ada68ccd8f', 'duration': 120, 'emissions_sum': 5.2250050747394564e-05, 'emissions_rate': 0.0004353253957195536, 'cpu_power': 22.5, 'gpu_power': 0.0, 'ram_power': 6.0, 'cpu_energy': 0.0007500239610671998, 'gpu_energy': 0, 'ram_energy': 0.00019997696161270145, 'energy_consumed': 0.0009500009226799011} to https://api.codecarbon.io/emission\n",
+      "[codecarbon DEBUG @ 08:42:56] last_duration=14.996708154678345\n",
+      "------------------------\n",
+      "[codecarbon INFO @ 08:43:11] Energy consumed for RAM : 0.000225 kWh. RAM Power : 6.0 W\n",
+      "[codecarbon DEBUG @ 08:43:11] RAM : 6.00 W during 15.00 s [measurement time: 0.0011]\n",
+      "[codecarbon INFO @ 08:43:11] Energy consumed for all CPUs : 0.000844 kWh. All CPUs Power : 22.5 W\n",
+      "[codecarbon DEBUG @ 08:43:11] CPU : 22.50 W during 15.00 s [measurement time: 0.0009]\n",
+      "[codecarbon INFO @ 08:43:11] 0.001069 kWh of electricity used since the begining.\n",
+      "[codecarbon DEBUG @ 08:43:11] last_duration=14.99776005744934\n",
+      "------------------------\n",
+      "[codecarbon INFO @ 08:43:26] Energy consumed for RAM : 0.000250 kWh. RAM Power : 6.0 W\n",
+      "[codecarbon DEBUG @ 08:43:26] RAM : 6.00 W during 15.00 s [measurement time: 0.0010]\n",
+      "[codecarbon INFO @ 08:43:26] Energy consumed for all CPUs : 0.000938 kWh. All CPUs Power : 22.5 W\n",
+      "[codecarbon DEBUG @ 08:43:26] CPU : 22.50 W during 15.00 s [measurement time: 0.0010]\n",
+      "[codecarbon INFO @ 08:43:26] 0.001187 kWh of electricity used since the begining.\n",
+      "[codecarbon DEBUG @ 08:43:26] last_duration=15.00241208076477\n",
+      "------------------------\n",
+      "[codecarbon INFO @ 08:43:41] Energy consumed for RAM : 0.000275 kWh. RAM Power : 6.0 W\n",
+      "[codecarbon DEBUG @ 08:43:41] RAM : 6.00 W during 15.00 s [measurement time: 0.0019]\n",
+      "[codecarbon INFO @ 08:43:41] Energy consumed for all CPUs : 0.001031 kWh. All CPUs Power : 22.5 W\n",
+      "[codecarbon DEBUG @ 08:43:41] CPU : 22.50 W during 15.00 s [measurement time: 0.0008]\n",
+      "[codecarbon INFO @ 08:43:41] 0.001306 kWh of electricity used since the begining.\n",
+      "[codecarbon DEBUG @ 08:43:41] last_duration=15.00098705291748\n",
+      "------------------------\n",
+      "[codecarbon INFO @ 08:43:56] Energy consumed for RAM : 0.000300 kWh. RAM Power : 6.0 W\n",
+      "[codecarbon DEBUG @ 08:43:56] RAM : 6.00 W during 15.00 s [measurement time: 0.0015]\n",
+      "[codecarbon INFO @ 08:43:56] Energy consumed for all CPUs : 0.001125 kWh. All CPUs Power : 22.5 W\n",
+      "[codecarbon DEBUG @ 08:43:56] CPU : 22.50 W during 15.00 s [measurement time: 0.0009]\n",
+      "[codecarbon INFO @ 08:43:56] 0.001425 kWh of electricity used since the begining.\n",
+      "[codecarbon DEBUG @ 08:43:56] last_duration=14.999660730361938\n",
+      "------------------------\n",
+      "[codecarbon INFO @ 08:44:11] Energy consumed for RAM : 0.000325 kWh. RAM Power : 6.0 W\n",
+      "[codecarbon DEBUG @ 08:44:11] RAM : 6.00 W during 15.00 s [measurement time: 0.0020]\n",
+      "[codecarbon INFO @ 08:44:11] Energy consumed for all CPUs : 0.001219 kWh. All CPUs Power : 22.5 W\n",
+      "[codecarbon DEBUG @ 08:44:11] CPU : 22.50 W during 15.00 s [measurement time: 0.0007]\n",
+      "[codecarbon INFO @ 08:44:11] 0.001544 kWh of electricity used since the begining.\n",
+      "[codecarbon DEBUG @ 08:44:11] last_duration=15.003331899642944\n",
+      "------------------------\n",
+      "[codecarbon INFO @ 08:44:26] Energy consumed for RAM : 0.000350 kWh. RAM Power : 6.0 W\n",
+      "[codecarbon DEBUG @ 08:44:26] RAM : 6.00 W during 15.00 s [measurement time: 0.0016]\n",
+      "[codecarbon INFO @ 08:44:26] Energy consumed for all CPUs : 0.001313 kWh. All CPUs Power : 22.5 W\n",
+      "[codecarbon DEBUG @ 08:44:26] CPU : 22.50 W during 15.00 s [measurement time: 0.0008]\n",
+      "[codecarbon INFO @ 08:44:26] 0.001663 kWh of electricity used since the begining.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[codecarbon DEBUG @ 08:44:26] last_duration=15.000364780426025\n",
+      "------------------------\n",
+      "[codecarbon INFO @ 08:44:41] Energy consumed for RAM : 0.000375 kWh. RAM Power : 6.0 W\n",
+      "[codecarbon DEBUG @ 08:44:41] RAM : 6.00 W during 15.00 s [measurement time: 0.0007]\n",
+      "[codecarbon INFO @ 08:44:41] Energy consumed for all CPUs : 0.001406 kWh. All CPUs Power : 22.5 W\n",
+      "[codecarbon DEBUG @ 08:44:41] CPU : 22.50 W during 15.00 s [measurement time: 0.0004]\n",
+      "[codecarbon INFO @ 08:44:41] 0.001781 kWh of electricity used since the begining.\n",
+      "[codecarbon DEBUG @ 08:44:41] last_duration=15.000006198883057\n",
+      "------------------------\n",
+      "[codecarbon INFO @ 08:44:56] Energy consumed for RAM : 0.000400 kWh. RAM Power : 6.0 W\n",
+      "[codecarbon DEBUG @ 08:44:56] RAM : 6.00 W during 15.00 s [measurement time: 0.0014]\n",
+      "[codecarbon INFO @ 08:44:56] Energy consumed for all CPUs : 0.001500 kWh. All CPUs Power : 22.5 W\n",
+      "[codecarbon DEBUG @ 08:44:56] CPU : 22.50 W during 15.00 s [measurement time: 0.0009]\n",
+      "[codecarbon INFO @ 08:44:56] 0.001900 kWh of electricity used since the begining.\n",
+      "[codecarbon DEBUG @ 08:44:56] We apply an energy mix of 55 g.CO2eq/kWh for France\n",
+      "[codecarbon DEBUG @ 08:44:56] EmissionsData(timestamp='2022-05-22T08:44:56', project_name='codecarbon', run_id='33635ffd-9142-4353-a5e1-a4ada68ccd8f', duration=120.02802419662476, emissions=5.2251894421875456e-05, emissions_rate=0.00043533078855216887, cpu_power=22.5, gpu_power=0.0, ram_power=6.0, cpu_energy=0.0007500498995184897, gpu_energy=0, ram_energy=0.0001999845445156098, energy_consumed=0.0009500344440340992, country_name='France', country_iso_code='FRA', region='île-de-france', cloud_provider='', cloud_region='', os='macOS-10.16-x86_64-i386-64bit', python_version='3.8.0', cpu_count=12, cpu_model='Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz', gpu_count=None, gpu_model=None, longitude=2.4075, latitude=48.8323, ram_total_size=16.0, tracking_mode='machine', on_cloud='N')\n",
+      "[codecarbon INFO @ 08:44:56] 0.000435 g.CO2eq/s mean an estimation of 13.728591747781197 kg.CO2eq/year\n",
+      "[codecarbon DEBUG @ 08:44:56] ApiClient - Successful upload emission {'timestamp': '2022-05-22T08:44:56.657273+02:00', 'run_id': '33635ffd-9142-4353-a5e1-a4ada68ccd8f', 'duration': 120, 'emissions_sum': 5.2251894421875456e-05, 'emissions_rate': 0.00043533078855216887, 'cpu_power': 22.5, 'gpu_power': 0.0, 'ram_power': 6.0, 'cpu_energy': 0.0007500498995184897, 'gpu_energy': 0, 'ram_energy': 0.0001999845445156098, 'energy_consumed': 0.0009500344440340992} to https://api.codecarbon.io/emission\n",
+      "[codecarbon DEBUG @ 08:44:56] last_duration=15.003461122512817\n",
+      "------------------------\n",
+      "[codecarbon INFO @ 08:45:11] Energy consumed for RAM : 0.000425 kWh. RAM Power : 6.0 W\n",
+      "[codecarbon DEBUG @ 08:45:11] RAM : 6.00 W during 15.00 s [measurement time: 0.0013]\n",
+      "[codecarbon INFO @ 08:45:11] Energy consumed for all CPUs : 0.001594 kWh. All CPUs Power : 22.5 W\n",
+      "[codecarbon DEBUG @ 08:45:11] CPU : 22.50 W during 15.00 s [measurement time: 0.0009]\n",
+      "[codecarbon INFO @ 08:45:11] 0.002019 kWh of electricity used since the begining.\n",
+      "[codecarbon DEBUG @ 08:45:11] last_duration=14.997701168060303\n",
+      "------------------------\n",
+      "[codecarbon INFO @ 08:45:26] Energy consumed for RAM : 0.000450 kWh. RAM Power : 6.0 W\n",
+      "[codecarbon DEBUG @ 08:45:26] RAM : 6.00 W during 15.00 s [measurement time: 0.0014]\n",
+      "[codecarbon INFO @ 08:45:26] Energy consumed for all CPUs : 0.001688 kWh. All CPUs Power : 22.5 W\n",
+      "[codecarbon DEBUG @ 08:45:26] CPU : 22.50 W during 15.00 s [measurement time: 0.0009]\n",
+      "[codecarbon INFO @ 08:45:26] 0.002138 kWh of electricity used since the begining.\n",
+      "[codecarbon DEBUG @ 08:45:26] last_duration=15.00013518333435\n",
+      "------------------------\n",
+      "[codecarbon INFO @ 08:45:41] Energy consumed for RAM : 0.000475 kWh. RAM Power : 6.0 W\n",
+      "[codecarbon DEBUG @ 08:45:41] RAM : 6.00 W during 15.00 s [measurement time: 0.0015]\n",
+      "[codecarbon INFO @ 08:45:41] Energy consumed for all CPUs : 0.001781 kWh. All CPUs Power : 22.5 W\n",
+      "[codecarbon DEBUG @ 08:45:41] CPU : 22.50 W during 15.00 s [measurement time: 0.0010]\n",
+      "[codecarbon INFO @ 08:45:41] 0.002256 kWh of electricity used since the begining.\n",
+      "[codecarbon DEBUG @ 08:45:41] last_duration=15.00286078453064\n",
+      "------------------------\n",
+      "[codecarbon INFO @ 08:45:56] Energy consumed for RAM : 0.000500 kWh. RAM Power : 6.0 W\n",
+      "[codecarbon DEBUG @ 08:45:56] RAM : 6.00 W during 15.00 s [measurement time: 0.0014]\n",
+      "[codecarbon INFO @ 08:45:56] Energy consumed for all CPUs : 0.001875 kWh. All CPUs Power : 22.5 W\n",
+      "[codecarbon DEBUG @ 08:45:56] CPU : 22.50 W during 15.00 s [measurement time: 0.0011]\n",
+      "[codecarbon INFO @ 08:45:56] 0.002375 kWh of electricity used since the begining.\n",
+      "[codecarbon DEBUG @ 08:45:56] last_duration=14.9985032081604\n",
+      "------------------------\n",
+      "[codecarbon INFO @ 08:46:11] Energy consumed for RAM : 0.000525 kWh. RAM Power : 6.0 W\n",
+      "[codecarbon DEBUG @ 08:46:11] RAM : 6.00 W during 15.00 s [measurement time: 0.0014]\n",
+      "[codecarbon INFO @ 08:46:11] Energy consumed for all CPUs : 0.001969 kWh. All CPUs Power : 22.5 W\n",
+      "[codecarbon DEBUG @ 08:46:11] CPU : 22.50 W during 15.00 s [measurement time: 0.0012]\n",
+      "[codecarbon INFO @ 08:46:11] 0.002494 kWh of electricity used since the begining.\n",
+      "[codecarbon DEBUG @ 08:46:11] last_duration=15.000789880752563\n",
+      "------------------------\n",
+      "[codecarbon INFO @ 08:46:26] Energy consumed for RAM : 0.000550 kWh. RAM Power : 6.0 W\n",
+      "[codecarbon DEBUG @ 08:46:26] RAM : 6.00 W during 15.00 s [measurement time: 0.0013]\n",
+      "[codecarbon INFO @ 08:46:26] Energy consumed for all CPUs : 0.002063 kWh. All CPUs Power : 22.5 W\n",
+      "[codecarbon DEBUG @ 08:46:26] CPU : 22.50 W during 15.00 s [measurement time: 0.0008]\n",
+      "[codecarbon INFO @ 08:46:26] 0.002612 kWh of electricity used since the begining.\n",
+      "[codecarbon DEBUG @ 08:46:26] last_duration=14.997332096099854\n",
+      "------------------------\n",
+      "[codecarbon INFO @ 08:46:41] Energy consumed for RAM : 0.000575 kWh. RAM Power : 6.0 W\n",
+      "[codecarbon DEBUG @ 08:46:41] RAM : 6.00 W during 15.00 s [measurement time: 0.0016]\n",
+      "[codecarbon INFO @ 08:46:41] Energy consumed for all CPUs : 0.002156 kWh. All CPUs Power : 22.5 W\n",
+      "[codecarbon DEBUG @ 08:46:41] CPU : 22.50 W during 15.00 s [measurement time: 0.0007]\n",
+      "[codecarbon INFO @ 08:46:41] 0.002731 kWh of electricity used since the begining.\n",
+      "[codecarbon DEBUG @ 08:46:41] last_duration=15.003536939620972\n",
+      "------------------------\n",
+      "[codecarbon INFO @ 08:46:56] Energy consumed for RAM : 0.000600 kWh. RAM Power : 6.0 W\n",
+      "[codecarbon DEBUG @ 08:46:56] RAM : 6.00 W during 15.00 s [measurement time: 0.0009]\n",
+      "[codecarbon INFO @ 08:46:56] Energy consumed for all CPUs : 0.002250 kWh. All CPUs Power : 22.5 W\n",
+      "[codecarbon DEBUG @ 08:46:56] CPU : 22.50 W during 15.00 s [measurement time: 0.0007]\n",
+      "[codecarbon INFO @ 08:46:56] 0.002850 kWh of electricity used since the begining.\n",
+      "[codecarbon DEBUG @ 08:46:56] We apply an energy mix of 55 g.CO2eq/kWh for France\n",
+      "[codecarbon DEBUG @ 08:46:56] EmissionsData(timestamp='2022-05-22T08:46:56', project_name='codecarbon', run_id='33635ffd-9142-4353-a5e1-a4ada68ccd8f', duration=120.01736879348755, emissions=5.224808230797449e-05, emissions_rate=0.0004353376751483124, cpu_power=22.5, gpu_power=0.0, ram_power=6.0, cpu_energy=0.0007499937772750857, gpu_energy=0, ram_energy=0.00019997135559717818, energy_consumed=0.0009499651328722636, country_name='France', country_iso_code='FRA', region='île-de-france', cloud_provider='', cloud_region='', os='macOS-10.16-x86_64-i386-64bit', python_version='3.8.0', cpu_count=12, cpu_model='Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz', gpu_count=None, gpu_model=None, longitude=2.4075, latitude=48.8323, ram_total_size=16.0, tracking_mode='machine', on_cloud='N')\n",
+      "[codecarbon INFO @ 08:46:56] 0.000435 g.CO2eq/s mean an estimation of 13.72880892347718 kg.CO2eq/year\n",
+      "[codecarbon DEBUG @ 08:46:56] ApiClient - Successful upload emission {'timestamp': '2022-05-22T08:46:56.674214+02:00', 'run_id': '33635ffd-9142-4353-a5e1-a4ada68ccd8f', 'duration': 120, 'emissions_sum': 5.224808230797449e-05, 'emissions_rate': 0.0004353376751483124, 'cpu_power': 22.5, 'gpu_power': 0.0, 'ram_power': 6.0, 'cpu_energy': 0.0007499937772750857, 'gpu_energy': 0, 'ram_energy': 0.00019997135559717818, 'energy_consumed': 0.0009499651328722636} to https://api.codecarbon.io/emission\n",
+      "[codecarbon DEBUG @ 08:46:56] last_duration=14.99814510345459\n",
+      "------------------------\n"
      ]
     }
    ],
@@ -247,7 +415,7 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "c61fec40",
+   "id": "6d7d1a9c",
    "metadata": {},
    "outputs": [
     {
@@ -326,7 +494,7 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "bdb0a17d",
+   "id": "7329fe3e",
    "metadata": {},
    "outputs": [
     {
@@ -397,7 +565,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "db8a30f1",
+   "id": "e9acf20a",
    "metadata": {},
    "source": [
     "## Model output"
@@ -406,7 +574,7 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "id": "1d3426e3",
+   "id": "03153add",
    "metadata": {},
    "outputs": [
     {
@@ -494,7 +662,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5d3c2786",
+   "id": "23e567ef",
    "metadata": {},
    "source": [
     "## Model"
@@ -503,7 +671,7 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "id": "8b498ee3",
+   "id": "bcc34626",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -529,7 +697,7 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "id": "a5df8ca2",
+   "id": "8df7fe1b",
    "metadata": {},
    "outputs": [
     {
@@ -579,7 +747,7 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "id": "cec2d376",
+   "id": "274a175d",
    "metadata": {},
    "outputs": [
     {
@@ -600,7 +768,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1d3f44b0",
+   "id": "b8792987",
    "metadata": {},
    "source": [
     "# Train model"
@@ -609,7 +777,7 @@
   {
    "cell_type": "code",
    "execution_count": 18,
-   "id": "53441242",
+   "id": "446409f2",
    "metadata": {},
    "outputs": [
     {
@@ -43510,7 +43678,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2d157d84",
+   "id": "337a2265",
    "metadata": {},
    "source": [
     "## Save model and resources"
@@ -43519,7 +43687,7 @@
   {
    "cell_type": "code",
    "execution_count": 19,
-   "id": "57749e9c",
+   "id": "f2af7444",
    "metadata": {},
    "outputs": [
     {
@@ -43600,7 +43768,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6ebb0214",
+   "id": "3dcca42b",
    "metadata": {},
    "source": [
     "## Training stats"
@@ -43609,7 +43777,7 @@
   {
    "cell_type": "code",
    "execution_count": 25,
-   "id": "ab63d125",
+   "id": "dd28541d",
    "metadata": {},
    "outputs": [
     {
@@ -44026,7 +44194,7 @@
   {
    "cell_type": "code",
    "execution_count": 42,
-   "id": "c6244c7a",
+   "id": "f157a4fc",
    "metadata": {},
    "outputs": [
     {
@@ -44053,7 +44221,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "38a29603",
+   "id": "4da55689",
    "metadata": {},
    "source": [
     "# Test model"
@@ -44062,7 +44230,7 @@
   {
    "cell_type": "code",
    "execution_count": 43,
-   "id": "cdba60dc",
+   "id": "572a040f",
    "metadata": {},
    "outputs": [
     {
@@ -44088,7 +44256,7 @@
   {
    "cell_type": "code",
    "execution_count": 44,
-   "id": "cff4364b",
+   "id": "f22b9950",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -44097,7 +44265,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7ee83647",
+   "id": "d1797611",
    "metadata": {},
    "source": [
     "## Predict with training model"
@@ -44106,7 +44274,7 @@
   {
    "cell_type": "code",
    "execution_count": 45,
-   "id": "fcb0f069",
+   "id": "ec151bc6",
    "metadata": {},
    "outputs": [
     {
@@ -44185,7 +44353,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "061aa1a7",
+   "id": "2c625975",
    "metadata": {},
    "source": [
     "## Predict with serving model"
@@ -44194,7 +44362,7 @@
   {
    "cell_type": "code",
    "execution_count": 46,
-   "id": "2df9fcc3",
+   "id": "d037eb41",
    "metadata": {},
    "outputs": [
     {
@@ -44283,7 +44451,7 @@
   {
    "cell_type": "code",
    "execution_count": 47,
-   "id": "554e2998",
+   "id": "22aa59ff",
    "metadata": {},
    "outputs": [
     {
@@ -44307,7 +44475,7 @@
   {
    "cell_type": "code",
    "execution_count": 48,
-   "id": "fb2d9a2d",
+   "id": "e6731585",
    "metadata": {},
    "outputs": [
     {
@@ -44406,7 +44574,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -44420,7 +44588,25 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.8.0"
+  },
+  "toc": {
+   "base_numbering": 1,
+   "nav_menu": {},
+   "number_sections": false,
+   "sideBar": true,
+   "skip_h1_title": false,
+   "title_cell": "Table of Contents",
+   "title_sidebar": "Contents",
+   "toc_cell": false,
+   "toc_position": {
+    "height": "calc(100% - 180px)",
+    "left": "10px",
+    "top": "150px",
+    "width": "266.796875px"
+   },
+   "toc_section_display": true,
+   "toc_window_display": true
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
### What
- Remove manual Table Of Content from notebook
- Instead, install and use toc2 nbextension (which manages automatic table of content within the notebook)
    - make sure notebook version is 4.x or 5.x, if not
       - pip uninstall notebook
       - pip install notebook==5 
    - then install extension from command line:
       - pip install jupyter_contrib_nbextensions jupyter_nbextensions_configurator
       - jupyter contrib nbextension install --user

The installation will add a tab to your Jupyter Notebook Tree where you can check and uncheck which extensions to enable

### Screenshot
<img width="1188" alt="Capture d’écran 2022-05-22 à 09 02 50" src="https://user-images.githubusercontent.com/83622933/169683104-acfd7c81-3d04-4039-9433-439c7c8298cf.png">


<img width="1221" alt="Capture d’écran 2022-05-22 à 08 55 51" src="https://user-images.githubusercontent.com/83622933/169682920-7fe1365f-7939-4244-88ca-d7a748f8565a.png">

